### PR TITLE
fix: import Stream from futures_core in bytes.rs

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
-use futures_util::Stream;
+use futures_core::Stream;
 use pin_project::pin_project;
 use tokio_util::io::poll_read_buf;
 


### PR DESCRIPTION
This enables using the `bytes` feature with `--no-default-features`.